### PR TITLE
Try to get M1 builds working

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,6 @@ compiler_stack: comp7
 max_py_ver: '37'
 max_r_ver: '35'
 conda_forge_output_validation: true
+build_platform:
+  osx_arm64: osx_64
+test_on_native_only: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@
 
 export FFLAGS=$(echo "${FFLAGS}" | sed "s/-fopenmp//g")
 
-cmake -D CMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR
+cmake ${CMAKE_ARGS} -D CMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR
 
 make -j${CPU_COUNT}
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
       - no_ffpe-summary.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Try to get a build for osx_arm64 (M1 Macs) working, following instructions at https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/



<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
